### PR TITLE
refactor : 영속화 update -> query update

### DIFF
--- a/backend/src/main/java/com/yata/backend/domain/yata/batch/YataBatchConfig.java
+++ b/backend/src/main/java/com/yata/backend/domain/yata/batch/YataBatchConfig.java
@@ -2,20 +2,15 @@ package com.yata.backend.domain.yata.batch;
 
 import com.yata.backend.domain.yata.entity.Yata;
 import com.yata.backend.domain.yata.repository.yataRepo.JpaYataRepository;
-import com.yata.backend.domain.yata.repository.yataRepo.YataRepository;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.Step;
 import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
 import org.springframework.batch.core.configuration.annotation.JobBuilderFactory;
 import org.springframework.batch.core.configuration.annotation.StepBuilderFactory;
-import org.springframework.batch.item.ItemReader;
-import org.springframework.batch.item.ItemWriter;
 import org.springframework.batch.repeat.RepeatStatus;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-
-import java.util.List;
 
 @Configuration
 @Slf4j
@@ -43,12 +38,7 @@ public class YataBatchConfig {
     public Step yataStep() {
         return stepBuilderFactory.get("yataStep")
                 .tasklet((contribution, chunkContext) -> {
-                    yataRepository.findAllYataOverDepartureTime().forEach(
-                            yata -> {
-                                yata.setPostStatus(Yata.PostStatus.POST_CLOSED);
-                                log.info("YataBatchConfig yataStep yata :{}", yata);
-                            }
-                    );
+                    yataRepository.updateYataOverDepartureTime();
                     return RepeatStatus.FINISHED;
                 }).build();
 

--- a/backend/src/main/java/com/yata/backend/domain/yata/repository/yataRepo/YataRepository.java
+++ b/backend/src/main/java/com/yata/backend/domain/yata/repository/yataRepo/YataRepository.java
@@ -8,5 +8,5 @@ import java.util.List;
 
 public interface YataRepository {
     List<Yata> findYataByStartAndEndLocation(Location startLocation, Location endLocation,double distance , Pageable pageable);
-    List<Yata> findAllYataOverDepartureTime();
+    void updateYataOverDepartureTime();
 }

--- a/backend/src/main/java/com/yata/backend/domain/yata/repository/yataRepo/YataRepositoryImpl.java
+++ b/backend/src/main/java/com/yata/backend/domain/yata/repository/yataRepo/YataRepositoryImpl.java
@@ -54,15 +54,13 @@ public class YataRepositoryImpl implements YataRepository {
     }
 
     @Override
-    public List<Yata> findAllYataOverDepartureTime() {
+    public void updateYataOverDepartureTime() {
         Date now = new Date();
-        List<Yata> yatas = queryFactory.selectFrom(yata)
-                .join(yata.member).fetchJoin()
-                .join(yata.strPoint).fetchJoin()
-                .join(yata.destination).fetchJoin()
-                .leftJoin(yata.yataMembers).fetchJoin()
+        queryFactory.update(yata)
+                .set(yata.postStatus, Yata.PostStatus.POST_CLOSED)
                 .where(yata.departureTime.before(now).and(yata.postStatus.eq(Yata.PostStatus.POST_OPEN)))
-                .fetch();
-        return yatas;
+                .execute();
+        em.flush();
+        em.clear();
     }
 }

--- a/backend/src/test/java/com/yata/backend/domain/Yata/repository/yataRepo/YataRepositoryImplTest.java
+++ b/backend/src/test/java/com/yata/backend/domain/Yata/repository/yataRepo/YataRepositoryImplTest.java
@@ -10,7 +10,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
@@ -22,7 +21,7 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.*;
 
 @ExtendWith(SpringExtension.class)
-@SpringBootTest
+@SpringBootTest(properties = "spring.jpa.show-sql=false")
 @Slf4j
 @Transactional
 class YataRepositoryImplTest {
@@ -47,8 +46,12 @@ class YataRepositoryImplTest {
                 .filter(yata -> yata.getDepartureTime().getTime() < System.currentTimeMillis())
                 .filter(yata -> yata.getPostStatus().equals(Yata.PostStatus.POST_OPEN))
                 .count();
-        List<Yata> yatas = jpaYataRepository.findAllYataOverDepartureTime();
-        assertEquals(count, yatas.size());
+        jpaYataRepository.updateYataOverDepartureTime();
+        long findCount = jpaYataRepository.findAll().stream()
+                .filter(yata -> yata.getDepartureTime().getTime() < System.currentTimeMillis())
+                .filter(yata -> yata.getPostStatus().equals(Yata.PostStatus.POST_CLOSED))
+                .count();
+        assertEquals(count, findCount);
         log.info("count : " + count);
 
     }


### PR DESCRIPTION
## 작업 내용 (Content)
- update 방식을 영속화 하고 1개 씩 업데이트 하는 방식에서 update 쿼리를 날리는 것으로 변경 ( 전체 )
- 쿼리 수 급격한 감소 
- yata 100 개 SELECT 기준 ( yata 1 , location 2 , member role 1  , update 1) * 100 -> 1  O(n) -> O(1)    
## 기타 사항 (Etc)
- PR에 대한 추가 설명이나 작업하면서 고민이 되었던 부분 등

## Merge 전 필요 작업 (Checklist before merge)
- [ ] 예) XX 테이블 추가, 앱 배포 등
- [ ] eg) Create XX table, Deploy app etc

## Merge 후 필요 작업 (Checklist after merge)
- PR이 생성되면 코드 리뷰 요청한 개발자에게 슬랙으로 알려주세요.
